### PR TITLE
Bugfixes, naming conventions, optimization

### DIFF
--- a/compute.jl
+++ b/compute.jl
@@ -60,9 +60,6 @@ function getindex(qubit::Qubit, i::Int)
     return qubit.vector[i]
 end
 
-# Checks if two qubits are in eps2 range of each other. Note that
-# abs2 calculates abs(x - y)^2, so make sure to pass eps^2 for the
-# comparison (abs2 is more efficient than abs)
 function isapprox(q1::Qubit, q2::Qubit, atol=0.0001)
     for (x, y) in zip(q1.vector, q2.vector)
         if !isapprox(x, y, atol=0.0001)

--- a/compute.jl
+++ b/compute.jl
@@ -3,182 +3,170 @@
 # Purpose: To perform the computations necessary for each gate in the QSPICE
 #          program
 #
-#   Notes: Multiple qubit states can be created with the kron function
+#   Notes: Multiple Qubit states can be created with the kron function
 #          We can only swap between adjacent positions
 #          This should just be swapping the xth and yth row in the ID matrix
 #
 #-----------------------------------------------------------------------------=#
 
-# First, the qubit type. Defined on Bloch sphere
-type bloch
+import Base.getindex
+
+# First, the Qubit type. Defined on Bloch sphere
+type Bloch
     r::Float64
     phi::Float64
     theta::Float64
 end
 
-# Now to hold the information from the qubit
-type qubit
+# Now to hold the information from the Qubit
+type Qubit
     element::Array{Complex}
 end
 
-# Define some gates (for testing)
-type quantum_gate
-    H
-    N
-    Id
-    Swap
-    Cnot
+function qubit()
+    return Qubit([0, 1])
 end
 
-H_gate = (1 / sqrt(2)) * [Complex(1) Complex(1); Complex(1) Complex(-1)]
+function qubit(angle::Bloch)
+    return Qubit([cos(angle.theta / 2),
+                  exp(im*angle.phi) * sin(angle.theta / 2)])
+end
 
-Identity = [1 0; 0 1]
+function approx_eq(q1::Qubit, q2::Qubit)
+    for (x, y) in zip(q1.element, q2.element)
+        if abs2(x - y) > 0.0001
+            return false
+        end
+    end
+    return true
+end
 
-N_gate = [Complex(0) Complex(1); Complex(1) Complex(0)]
+function getindex(qubit::Qubit, i::Int)
+    return qubit.element[i]
+end
 
-swap_gate = [Complex(1) Complex(0) Complex(0) Complex(0);
-             Complex(0) Complex(0) Complex(1) Complex(0);
-             Complex(0) Complex(1) Complex(0) Complex(0);
-             Complex(0) Complex(0) Complex(0) Complex(1)]
-
-Control_n = [Complex(1) Complex(0) Complex(0) Complex(0);
-             Complex(0) Complex(1) Complex(0) Complex(0);
-             Complex(0) Complex(0) Complex(0) Complex(1);
-             Complex(0) Complex(0) Complex(1) Complex(0)]
-
-gate = quantum_gate(H_gate, N_gate, Identity, swap_gate, Control_n)
+const IDENTITY = [Complex(1) 0; 0 1]
 
 #=-----------------------------------------------------------------------------#
 # FUNCTION
 #-----------------------------------------------------------------------------=#
 
-# Converting qubit type for manipulation later
-# This should convert a qubit to the surface of the Bloch sphere
-function bloch_to_qubit(angle::bloch)
-    # Creating the cubit
-    bit = initialize()
-
-    # define ray
-    # Note: Not sure where to put these
-    bit.element[1] = cos(angle.theta / 2)
-    bit.element[2] = exp(im*angle.phi) * sin(angle.theta / 2)
-
-    return bit
-end
-
-# initializes a single qubit in the |0> state
-function initialize()
-    bit = qubit([1,0])
-    return bit
-end
-
 # Implement Hadamard gate
-function hadamard(bit::qubit, gate, num)
+function hadamard(bit::Qubit, num = 1)
+    const hadamard_matrix = (1 / sqrt(2)) * [Complex(1) Complex(1); Complex(1) Complex(-1)]
+
     # Create initial gate structure
-    root_num = log2(size(bit.element, 1))
-    gate_array = [gate.Id for i = 1:Int(root_num)]
+    root_num = Int(log2(size(bit.element, 1)))
+    if root_num == 0
+        return Qubit(hadamard_matrix * bit.element)
+    end
 
-    gate_array[num] = gate.H
- 
-    bit.element = kron(gate_array...) * bit.element
-
-    return bit
+    gate_array::Array{Any,1} = [IDENTITY for i = 1:root_num]
+    gate_array[num] = hadamard_matrix
+    return Qubit(kron(gate_array...) * bit.element)
 end
 
 # Implementing the not gate
-function not(bit::qubit)
-    N_gate = [Complex(0) Complex(1); Complex(1) Complex(0)]
-    bit.element = N_gate * bit.element
-    return bit
+function not(bit::Qubit)
+    const not_matrix = [Complex(0) Complex(1); Complex(1) Complex(0)]
+    return Qubit(not_matrix * bit.element)
 end
 
 # Implementing a rotation gate
-function rotation(bit::qubit, theta)
-    R_gate = [Complex(1) Complex(0); Complex(0) Complex(exp(im * theta))]
-    bit.element = R_gate * bit.element
-    return bit
+function rotation(bit::Qubit, theta)
+    const rotation_matrix = [Complex(1) Complex(0); Complex(0) Complex(exp(im * theta))]
+    return Qubit(rotation_matrix * bit.element)
 end
 
 # Implementing the swap gate
-# ERROR: We need to account for swapping everything back.
-function swap(bit::qubit, gate, num1, num2)
+function swap(bit::Qubit, from = 1, to = 2)
+    const swap_matrix = [Complex(1) Complex(0) Complex(0) Complex(0);
+                         Complex(0) Complex(0) Complex(1) Complex(0);
+                         Complex(0) Complex(1) Complex(0) Complex(0);
+                         Complex(0) Complex(0) Complex(0) Complex(1)]
+
+    if from == to
+        return Qubit(copy(bit.element))
+    end
+
     # Create initial gate structure
     # Number of bits = root_num
-    root_num = log2(size(bit.element, 1))
+    root_num = Int(log2(size(bit.element, 1)))
 
-    # final gate for multiplication
-    big_gate = []
+    if root_num <= 1
+        return Qubit(copy(bit.element))
+    elseif root_num == 2
+        test = swap_matrix * bit.element
+        return Qubit(swap_matrix * bit.element)
+    end
 
     # moving from low to high
-    low = min(num1, num2)
-    high = max(num1, num2) -1
+    low = min(from, to)
+    high = max(from, to) - 1
 
-    # Defining gates
-    if root_num > 1
-        for i = low:high
-            gate_array = [gate.Id for i = 1:Int(root_num)-1]
+    # final gate for multiplication
+    swap_chain = []
 
-            gate_array[i] = gate.Swap
-
-            if i == low
-                big_gate = kron(gate_array...)
-            else
-                big_gate = big_gate * kron(gate_array...)
-            end
-            
-        end
-
-        for i = high-1:-1:low
-            gate_array = [gate.Id for i = 1:Int(root_num)-1]
-
-            gate_array[i] = gate.Swap
-
-            big_gate = big_gate * kron(gate_array...)
-
-        end
-
-        # Final multiplication
-        if abs(num1 - num2) > 0
-            bit.element = big_gate * bit.element
+    for i = low : high
+        gate_array = [IDENTITY for i = 1 : root_num - 1]
+        gate_array[i] = swap_matrix
+        if i == low
+            swap_chain = kron(gate_array...)
+        else
+            swap_chain = swap_chain * kron(gate_array...)
         end
     end
 
-    return bit
+    for i = high - 1 : -1 : low
+        gate_array = [gate.Id for i = 1:root_num - 1]
+        gate_array[i] = gate.Swap
+        swap_chain = swap_chain * kron(gate_array...)
+    end
+
+    return Qubit(swap_chain * bit.element)
 end
 
 # Implementing the Cnot function
 # Have not tested all cases, will look into later
-function cnot(bit::qubit, gate, control, flip)
-    root_num = log2(size(bit.element, 1))
-    big_gate = []
+function cnot(bit::Qubit, control, flip)
+    const cnot_matrix = [Complex(1) Complex(0) Complex(0) Complex(0);
+                         Complex(0) Complex(1) Complex(0) Complex(0);
+                         Complex(0) Complex(0) Complex(0) Complex(1);
+                         Complex(0) Complex(0) Complex(1) Complex(0)]
 
-    if root_num > 1
-        # Swap the bits into the appropriate positions of 1 and 2 for 
-        # control and flip, respectively.
+    root_num = Int(log2(size(bit.element, 1)))
 
-        # first swap everything into position
-        bit = swap(bit, gate, 1, control)
-        if flip != 1
-            bit = swap(bit, gate, 2, flip)
-        else
-            bit = swap(bit, gate, 2, control)
-        end
-
-        # performs cnot
-        gate_array = [gate.Id for i = 1:Int(root_num)-1]
-        gate_array[1] = gate.Cnot
-
-        bit.element = kron(gate_array...) * bit.element
-
-        # swaps back
-        if flip != 1
-            bit = swap(bit, gate, 2, flip)
-        else
-            bit = swap(bit, gate, 2, control)
-        end
-        bit = swap(bit, gate, 1, control)
+    if root_num <= 1
+        return bit
     end
 
+    cnot_chain = []
+
+    # Swap the bits into the appropriate positions of 1 and 2 for
+    # control and flip, respectively.
+
+    # first swap everything into position
+    bit = swap(bit, 1, control)
+    if flip != 1
+        bit = swap(bit, 2, flip)
+    else
+        bit = swap(bit, 2, control)
+    end
+
+    # performs cnot
+    gate_array = [IDENTITY for i = 1:root_num-1]
+    gate_array[1] = cnot_matrix
+
+    bit.element = kron(gate_array...) * bit.element
+
+    # swaps back
+    if flip != 1
+        bit = swap(bit, 2, flip)
+    else
+        bit = swap(bit, 2, control)
+    end
+
+    bit = swap(bit, gate, 1, control)
     return bit
 end
 
@@ -188,28 +176,32 @@ end
 
 # Testing of single bit
 
-bit_bloch = bloch(1,0,pi)
-bit = bloch_to_qubit(bit_bloch)
-println(bit.element[1], '\t', bit.element[2])
+bit_bloch = Bloch(1,0,pi)
+bit = qubit(bit_bloch)
+println(bit[1], '\t', bit[2])
 bit = rotation(bit, pi)
-println(bit.element[1], '\t', bit.element[2])
+println(bit[1], '\t', bit[2])
 
-# Testing multi-qubit operations
+# Testing multi-Qubit operations
 bit1 = [0;1]
-bit2 = [0;1]
+bit2 = [1;0]
 bit3 = [0;1]
 
-superbit = kron(bit1, bit2)
+superbit = Qubit(kron(bit1, bit2))
 println("superbit is: ", superbit)
 
 # H(1) -> swap -> H(2)
 # We can chain operations together (in reverse order):
-temp_bit = kron(Identity,H_gate) * swap_gate * kron(H_gate,Identity) * superbit
+# temp_bit = superbit |> q -> hadamard(q, 1) |> q -> swap(q, 1, 2) |> q -> hadamard(q, 2)
 
-println(temp_bit)
+temp_bit = superbit |> swap
+@show superbit
+@show temp_bit
 
-# 3 qubit is similar to above:
-superbit3 = qubit(kron(bit1, bit2, bit3))
+println(approx_eq(superbit, temp_bit))
+
+# 3 Qubit is similar to above:
+#superbit3 = Qubit(kron(bit1, bit2, bit3))
 #=
 println("original superbit")
 println(superbit3.element)
@@ -218,11 +210,11 @@ println("superbit after swap")
 println(superbit3.element)
 =#
 
-println(superbit3 == swap(swap(superbit3, gate, 1, 3), gate, 1, 3))
-
-superbit3 = cnot(superbit3, gate, 2, 1)
-println("superbit after cnot")
-println(superbit3.element)
+#println(superbit3 == swap(swap(superbit3, gate, 1, 3), gate, 1, 3))
+#
+#superbit3 = cnot(superbit3, gate, 2, 1)
+#println("superbit after cnot")
+#println(superbit3.element)
 
 # List of functions that need to be implemented
 #=

--- a/test.jl
+++ b/test.jl
@@ -1,6 +1,6 @@
 #=-------------test.jl---------------------------------------------------------#
 #
-# Purpose: To test the functions in the compute.jl file with the qubit 
+# Purpose: To test the functions in the compute.jl file with the qubit
 #          operations
 #
 #   Notes: FactCheck implements an assert-like function in Julia
@@ -15,41 +15,68 @@ include("compute.jl")
 using FactCheck
 using Iterators
 
-# Generates random qubit for later
-function random_qubit(length)
-    # initialize array to a random set of 1/0's
-    r_array = [rand(0:1) for i in 1:length]
+const QUBITS = Array[[0,0], [0,1], [1,0], [1,1]]
 
-    # create / return qubit
-    r_qubit = qubit(r_array)
-    return r_qubit
+# Generates random qubit for later
+function random_qubit(num_bits)
+    return qubit(reduce(kron, [QUBITS[rand(1:length(QUBITS))] for _ in 1:num_bits]))
 end
 
+function random_qubit_list(num_bits, n)
+    return [random_qubit(num_bits) for _ in 1:n]
+end
+
+# Generates all distinct quantum bit vectors for num_bits
+function exhaustive_list(num_bits)
+    arrays = ([(Array[x...]) for x in product([QUBITS for i=1:num_bits]...)])
+    states = imap(x -> kron(x...), arrays) |> distinct |> x -> imap(qubit, x) |> collect
+    return states
+end
+
+roughly(q1::Qubit) = (q2::Qubit) -> isapprox(q1, q2)
+
 # Fact checking / asserting that the swaps happen as expected
-facts("Checking the swap gate for all cases up to qubit length 5.") do
+facts("Swap gate tests") do
+    context("Test for a single qubit") do
+        q = qubit([0,1])
+        @fact q --> roughly(swap(q))
+        @fact q --> roughly(swap(swap(q)))
+        @fact q --> roughly(swap(q, 4, 5))
+        @fact q --> roughly(swap(swap(q, 1, 4), 4, 5))
+    end
 
-    # Creating initial states
-    state_1 = [0;1]
-    state_0 = [1;0]
-    
-    # using iterator
-    for i in product(0:1, 0:1, 0:1, 0:1, 0:1)
-
-        # generating qubit states from iterator
-        q_states = [state_0 for j in 1:length(i)]
-        for j in i
-            if j != 0
-                q_states[j] = state_1
-            end
-        end
-
-        test_qubit = qubit(kron(q_states...))
-
-        println(i)
-        for j = 1:5, k = 1:5
-            println(j, '\t', k)
-            @fact test_qubit --> swap(swap(test_qubit,gate,j,k),gate,j,k)
+    context("Exhaustive test for 2 qubits") do
+        qubits = exhaustive_list(2)
+        for q in qubits
+            @fact q --> roughly(swap(swap(q)))
         end
     end
 
+    context("Exhaustive test for 3 qubits") do
+        qubits = exhaustive_list(3)
+        for q in qubits
+            for j = 1:3, k = 1:3
+                @fact q --> roughly(swap(swap(q, j, k), j, k))
+            end
+        end
+    end
+
+    context("Exhaustive test for 4 qubits") do
+        qubits = exhaustive_list(4)
+        for q in qubits
+            for j = 1:4, k = 1:4
+                @fact q --> roughly(swap(swap(q, j, k), j, k))
+            end
+        end
+    end
+
+    context("Exhaustive test for 5 qubits") do
+        qubits = exhaustive_list(5)
+        swap(swap(qubits[1], 1, 4), 1, 5)
+        for q in qubits
+            for j = 1:5, k = 1:5
+                @fact q --> roughly(swap(swap(q, j, k), j, k))
+            end
+        end
+    end
 end

--- a/test.jl
+++ b/test.jl
@@ -47,6 +47,8 @@ facts("Swap gate tests") do
 
     context("Exhaustive test for 2 qubits") do
         qubits = exhaustive_list(2)
+        not_same = qubit(kron([0,1], [1,0]))
+        @fact not_same --> FactCheck.not(swap(not_same))
         for q in qubits
             @fact q --> roughly(swap(swap(q)))
         end


### PR DESCRIPTION
So this fixes quite a few things, from least to most important:
- Use the same naming convention as the Julia standard library
- Use built-in functions where applicable
- Nicer output for the tests in `compute.jl`
- Optimized constant quantum gate matrices: turned them into global const variables to help the optimizer
- Optimize swap function: moved a condition out of a for loop, should perform better
- Consistent use of quantum gates: use the functions for any number of qubits, no matrix multiplication for single qubits anymore (the functions just handle it correctly). More on this below.
- Improved the exhaustive test to only test distinct cases. This cuts down the runtime pretty significantly.
- Added proper tests that account for floating point precision. See `isapprox` to adjust the tolerance
- Fixed a pretty nasty bug: Julia, by default, passes arguments by reference. Before this PR, every gate changed the state of the initial qubit, making it impossible to track changes (and it would silently break if you wanted to use the output of a gate in two separate places). Also because of this, yesterday's unit tests weren't actually accurate: in `@fact q --> swap(swap(q))`, the swaps changed the value of `q`, so the comparisons would always turn out to be true.

The new gate chaining needs the Pipe package (`Pkg.add("Pipe")`). It allows nice function chaining with a handy macro:

``` julia
chaining = @pipe superbit |> hadamard(_, 1) |> swap(_, 1, 2) |> hadamard(_, 2)
```

The operations are executed from left to right (natural order), where `_` is the placeholder character for the quantum bit. This chaining is possible because I changed every gate function to return a new qubit instead of modifying the one that's been passed in (note: it's trivial to make mutating and non-mutating versions of the functions if necessary, see `swap` and `swap!` in the code).

Since I got rid of the special-casing for single qubits, the above syntax applies for any number of qubits, which makes it much more consistent overall.
